### PR TITLE
Fix Issue #1

### DIFF
--- a/syntaxes/go-sql-highlight.json
+++ b/syntaxes/go-sql-highlight.json
@@ -4,7 +4,7 @@
   "patterns": [
     {
       "name": "meta.embedded.block.sql",
-      "begin": "\\s*+(/\\* [sS][qQ][lL] \\*/)\\s*(`)",
+      "begin": "\\s*+(/\\* [sS][qQ][lL] \\*/)\\s*,?\\s*(`)",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.string.begin.go"


### PR DESCRIPTION
go linter puts the `/* sql */` comment before any comma. This will allow a comma to be between the comment and the start of the string.